### PR TITLE
Use NS_ASSUME_NONNULL to avoid warnings

### DIFF
--- a/KarteTracker.embeddedframework/KarteTracker.framework/Headers/KarteTracker.h
+++ b/KarteTracker.embeddedframework/KarteTracker.framework/Headers/KarteTracker.h
@@ -19,6 +19,8 @@
 #import "KarteVariable.h"
 #import "KarteVariables.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol KarteTrackerDelegate;
 @class KarteTrackerAppProfile;
 @class KarteTrackerUserProfile;
@@ -31,33 +33,35 @@
 @property (nonatomic, strong, readonly) KarteTrackerConfig *config;
 @property (nonatomic, copy, readonly, nonnull) NSString *visitorId;
 
-+ (nonnull instancetype)sharedTrackerWithAppKey:(nonnull NSString *)appKey NS_SWIFT_NAME(shared(appKey:));
-+ (nonnull instancetype)setupWithAppKey:(nonnull NSString *)appKey NS_SWIFT_NAME(setup(appKey:));
-+ (nonnull instancetype)setupWithAppKey:(nonnull NSString *)appKey withConfig:(nonnull KarteTrackerConfig *)config NS_SWIFT_NAME(setup(appKey:config:));
++ (instancetype)sharedTrackerWithAppKey:(NSString *)appKey NS_SWIFT_NAME(shared(appKey:));
++ (instancetype)setupWithAppKey:(NSString *)appKey NS_SWIFT_NAME(setup(appKey:));
++ (instancetype)setupWithAppKey:(NSString *)appKey withConfig:(KarteTrackerConfig *)config NS_SWIFT_NAME(setup(appKey:config:));
 
-- (nonnull instancetype)initWithAppKey:(nonnull NSString *)appKey NS_SWIFT_NAME(init(appKey:));
-- (nonnull instancetype)initWithAppKey:(nonnull NSString *)appKey withConfig:(nonnull KarteTrackerConfig *)config NS_SWIFT_NAME(init(appKey:config:));
+- (instancetype)initWithAppKey:(NSString *)appKey NS_SWIFT_NAME(init(appKey:));
+- (instancetype)initWithAppKey:(NSString *)appKey withConfig:(KarteTrackerConfig *)config NS_SWIFT_NAME(init(appKey:config:));
 
 @end
 
 
 @interface KarteTracker (Track)
-- (void)track:(nonnull NSString *)eventName values:(nullable NSDictionary *)values;
-- (void)trackNotification:(nonnull NSDictionary *)userInfo;
-- (void)trackUncaughtException:(nonnull NSDictionary *)values;
-- (void)identify:(nonnull NSDictionary *)values;
-- (void)view:(nonnull NSString *)viewName;
-- (void)view:(nonnull NSString *)viewName title:(nonnull NSString *)title;
-- (void)view:(nonnull NSString *)viewName title:(nonnull NSString *)title values:(nullable NSDictionary *)values;
-- (void)view:(nonnull NSString *)viewName values:(nullable NSDictionary *)values;
+- (void)track:(NSString *)eventName values:(nullable NSDictionary *)values;
+- (void)trackNotification:(NSDictionary *)userInfo;
+- (void)trackUncaughtException:(NSDictionary *)values;
+- (void)identify:(NSDictionary *)values;
+- (void)view:(NSString *)viewName;
+- (void)view:(NSString *)viewName title:(NSString *)title;
+- (void)view:(NSString *)viewName title:(NSString *)title values:(nullable NSDictionary *)values;
+- (void)view:(NSString *)viewName values:(nullable NSDictionary *)values;
 
-- (void)logoutWithCompletionBlock:(nonnull void (^)(BOOL isSuccessful))completion NS_SWIFT_NAME(logout(_:)) __attribute__((deprecated("Use -[KarteTracker logout]. since v1.5.3")));
+- (void)logoutWithCompletionBlock:(void (^)(BOOL isSuccessful))completion NS_SWIFT_NAME(logout(_:)) __attribute__((deprecated("Use -[KarteTracker logout]. since v1.5.3")));
 ;
 - (void)logout;
 @end
 
 
 @interface KarteTracker (FirebaseCloudMessaging)
-- (void)registerFCMToken:(nonnull NSString *)token;
-- (void)handleFCMRemoteMessage:(nonnull NSDictionary *)data;
+- (void)registerFCMToken:(NSString *)token;
+- (void)handleFCMRemoteMessage:(NSDictionary *)data;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/KarteTracker.embeddedframework/KarteTracker.framework/Headers/KarteTrackerConfig.h
+++ b/KarteTracker.embeddedframework/KarteTracker.framework/Headers/KarteTrackerConfig.h
@@ -10,12 +10,13 @@
 #import "KarteTrackerConfigBuilder.h"
 #import "KarteIDFADelegate.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface KarteTrackerConfig : NSObject
-@property (nonatomic, class, strong, readonly, nonnull) KarteTrackerConfig *configure;
+@property (nonatomic, class, strong, readonly) KarteTrackerConfig *configure;
 
-@property (nonatomic, copy, readonly, nonnull) NSString *trackEndpoint;
-@property (nonatomic, copy, readonly, nonnull) NSString *overlayEndpoint;
+@property (nonatomic, copy, readonly) NSString *trackEndpoint;
+@property (nonatomic, copy, readonly) NSString *overlayEndpoint;
 
 @property (nonatomic, assign, readonly, getter=isEnabledTrackingAppLifecycle) BOOL enabledTrackingAppLifecycle NS_SWIFT_NAME(isEnabledTrackingAppLifecycle);
 @property (nonatomic, assign, readonly, getter=isEnabledTrackingAppOpen) BOOL enabledTrackingAppOpen NS_SWIFT_NAME(isEnabledTrackingAppOpen);
@@ -25,7 +26,9 @@
 @property (nonatomic, assign, readonly, getter=isDryRun) BOOL dryRun NS_SWIFT_NAME(isDryRun);
 @property (nonatomic, weak, readonly, nullable) id<KarteIDFADelegate> IDFADelegate;
 
-- (nonnull instancetype)initWithBuilder:(KarteTrackerConfigBuilder *)builder NS_SWIFT_NAME(init(_:));
-+ (nonnull instancetype)configureWithBuilder:(void (^)(KarteTrackerConfigBuilder *_Nonnull builder))closure NS_SWIFT_NAME(configure(_:));
+- (instancetype)initWithBuilder:(KarteTrackerConfigBuilder *)builder NS_SWIFT_NAME(init(_:));
++ (instancetype)configureWithBuilder:(void (^)(KarteTrackerConfigBuilder * builder))closure NS_SWIFT_NAME(configure(_:));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/KarteTracker.embeddedframework/KarteTracker.framework/Headers/KarteVariables.h
+++ b/KarteTracker.embeddedframework/KarteTracker.framework/Headers/KarteVariables.h
@@ -9,20 +9,21 @@
 
 #import "KarteVariable.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface KarteVariables : NSObject
 @property (class, strong, readonly) KarteVariables *variables;
 
-- (nonnull instancetype)initWithAppKey:(nonnull NSString *)appKey NS_SWIFT_NAME(init(appKey:));
-+ (nonnull instancetype)variablesWithAppKey:(nonnull NSString *)appKey NS_SWIFT_NAME(variables(appKey:));
+- (instancetype)initWithAppKey:(NSString *)appKey NS_SWIFT_NAME(init(appKey:));
++ (instancetype)variablesWithAppKey:(NSString *)appKey NS_SWIFT_NAME(variables(appKey:));
 
 - (void)fetch;
 + (void)fetch;
-- (void)fetchWithCompletionBlock:(nonnull void (^)(BOOL isSuccessful))completion NS_SWIFT_NAME(fetch(_:));
-+ (void)fetchWithCompletionBlock:(nonnull void (^)(BOOL isSuccessful))completion NS_SWIFT_NAME(fetch(_:));
+- (void)fetchWithCompletionBlock:(void (^)(BOOL isSuccessful))completion NS_SWIFT_NAME(fetch(_:));
++ (void)fetchWithCompletionBlock:(void (^)(BOOL isSuccessful))completion NS_SWIFT_NAME(fetch(_:));
 
-- (nonnull KarteVariable *)variableForKey:(nonnull NSString *)key NS_SWIFT_NAME(variable(forKey:));
-+ (nonnull KarteVariable *)variableForKey:(nonnull NSString *)key NS_SWIFT_NAME(variable(forKey:));
+- (KarteVariable *)variableForKey:(NSString *)key NS_SWIFT_NAME(variable(forKey:));
++ (KarteVariable *)variableForKey:(NSString *)key NS_SWIFT_NAME(variable(forKey:));
 
 - (void)trackWithVariables:(NSArray *)variables withEventName:(NSString *)eventName NS_SWIFT_NAME(track(variables:eventName:));
 - (void)trackWithVariables:(NSArray *)variables withEventName:(NSString *)eventName withValues:(nullable NSDictionary *)values NS_SWIFT_NAME(track(variables:eventName:values:));
@@ -31,3 +32,5 @@
 + (void)trackWithVariables:(NSArray *)variables withEventName:(NSString *)eventName withValues:(nullable NSDictionary *)values NS_SWIFT_NAME(track(variables:eventName:values:));
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Some headers don't specify nullability, so using Xcode 10.2, warnings are raised.

<img width="492" alt="Screen Shot 2019-04-04 at 20 12 25" src="https://user-images.githubusercontent.com/147051/55551860-bb03db80-5716-11e9-8234-6071c985bbce.png">

So I added `NS_ASSUME_NONNULL_BEGIN` and `NS_ASSUME_NONNULL_END` to some headers.